### PR TITLE
Change the name of the MQTT client

### DIFF
--- a/esp-gardener/esp-gardener.ino
+++ b/esp-gardener/esp-gardener.ino
@@ -270,7 +270,7 @@ void reconnect() {
   reconnect_counter = 0;
   while (!client.connected()) {
     LOG("Attempting MQTT connection...");
-    if (client.connect("ESP8266Client")) {
+    if (client.connect("ESP8266Client_gardener")) {
       LOG("connected", true);
       publish_start();
       publish_waterlevel();      


### PR DESCRIPTION
When I ran both esp-gardener and esp-moisture-sensor, the MQTT broker had issues, because both clients had the same name.